### PR TITLE
### 투자자 정보 삭제시 암호 비교 루틴 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,6 +371,9 @@ gradle-app.setting
 !.vscode/extensions.json
 !.vscode/*.code-snippets
 
+### debug config
+.vscode/launch.json
+
 # Local History for Visual Studio Code
 .history/
 

--- a/src/api/allApiService.js
+++ b/src/api/allApiService.js
@@ -1,8 +1,8 @@
 // npm install 해주세요.
 import axios from "axios";
 
-//const BASE_URL = 'https://three-view-my-startup-3team-be.onrender.com';
-const BASE_URL = "http://localhost:8000";
+const BASE_URL = "https://three-view-my-startup-3team-be.onrender.com";
+// const BASE_URL = "http://localhost:8000";
 
 /**
  * 백엔드 api 라우터의 주석과 순서를 그대로 했습니다.
@@ -89,8 +89,10 @@ async function patchInvestment(id, surveyData) {
 }
 
 // 투자 삭제
-async function deleteInvestment(id) {
-  const url = await axios.delete(`${BASE_URL}/api/investments/${id}`);
+async function deleteInvestment(id, password) {
+  const url = await axios.delete(`${BASE_URL}/api/investments/${id}`, {
+    data: { password }, // 비밀번호를 요청 body에 포함
+  });
   return url.data;
 }
 

--- a/src/components/Footer/index.css
+++ b/src/components/Footer/index.css
@@ -5,7 +5,6 @@
   height: 180px;
   padding-top: 30px;
   filter: drop-shadow(0 0 0.75rem rgba(94, 94, 94, 0.283));
-  margin-top: auto;
 }
 
 .footerContent {

--- a/src/pages/DetailsPage/components/DeleteCompanyInvestment/index.jsx
+++ b/src/pages/DetailsPage/components/DeleteCompanyInvestment/index.jsx
@@ -80,6 +80,13 @@ function DeleteCompanyInvestment({ onClose, mockInvestor }) {
     } catch (err) {
       console.error("삭제 요청 중 오류 발생:", err);
       console.error(err.response.data);
+
+      // 비밀번호 불일치 등의 오류 처리
+      if (err.response && err.response.status === 401) {
+        alert("비밀번호가 일치하지 않습니다.");
+      } else {
+        alert("삭제 중 오류가 발생했습니다.");
+      }
     }
   };
 

--- a/src/pages/DetailsPage/components/DetailsPageHeader/index.jsx
+++ b/src/pages/DetailsPage/components/DetailsPageHeader/index.jsx
@@ -44,7 +44,6 @@ const CATEGORIES = [
 
 function DetailsPageheader() {
   const { startupId } = useParams();
-
   const { startup, error } = useFetchStartup(startupId);
 
   if (error) {


### PR DESCRIPTION
### 투자자 정보 삭제시 암호 비교 루틴 추가
- 프론트앤드에서 보낸 API 안에 비밀번호가 있다. 백앤드에서 데이터베이스에 저장된 비밀번호와 비교 후 맞으면 삭제.